### PR TITLE
Removing duplicated logic for retrieving container port

### DIFF
--- a/cmd/service-controller/definition_monitor.go
+++ b/cmd/service-controller/definition_monitor.go
@@ -122,7 +122,7 @@ func deducePort(deployment *appsv1.Deployment) int {
 			return 0
 		}
 	} else {
-		return int(kube.GetContainerPort(deployment))
+		return int(kube.GetContainerPort(deployment.Spec.Template))
 	}
 }
 
@@ -134,7 +134,7 @@ func deducePortFromStatefulSet(statefulSet *appsv1.StatefulSet) int {
 			return 0
 		}
 	} else {
-		return int(kube.GetContainerPortForStatefulSet(statefulSet))
+		return int(kube.GetContainerPort(statefulSet.Spec.Template))
 	}
 }
 
@@ -146,7 +146,7 @@ func deducePortFromDaemonSet(daemonSet *appsv1.DaemonSet) int {
 			return 0
 		}
 	} else {
-		return int(kube.GetContainerPortForDaemonSet(daemonSet))
+		return int(kube.GetContainerPort(daemonSet.Spec.Template))
 	}
 }
 

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -319,25 +319,9 @@ func NewTransportDeployment(van *types.RouterSpec, ownerRef *metav1.OwnerReferen
 	}
 }
 
-func GetContainerPort(deployment *appsv1.Deployment) int32 {
-	if len(deployment.Spec.Template.Spec.Containers) > 0 && len(deployment.Spec.Template.Spec.Containers[0].Ports) > 0 {
-		return deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
-	} else {
-		return 0
-	}
-}
-
-func GetContainerPortForStatefulSet(statefulSet *appsv1.StatefulSet) int32 {
-	if len(statefulSet.Spec.Template.Spec.Containers) > 0 && len(statefulSet.Spec.Template.Spec.Containers[0].Ports) > 0 {
-		return statefulSet.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
-	} else {
-		return 0
-	}
-}
-
-func GetContainerPortForDaemonSet(daemonSet *appsv1.DaemonSet) int32 {
-	if len(daemonSet.Spec.Template.Spec.Containers) > 0 && len(daemonSet.Spec.Template.Spec.Containers[0].Ports) > 0 {
-		return daemonSet.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
+func GetContainerPort(template corev1.PodTemplateSpec) int32 {
+	if len(template.Spec.Containers) > 0 && len(template.Spec.Containers[0].Ports) > 0 {
+		return template.Spec.Containers[0].Ports[0].ContainerPort
 	} else {
 		return 0
 	}


### PR DESCRIPTION
This is just a cosmetic change, but eventually might help reducing code dup and eventual issues.